### PR TITLE
[BE/FEAT] Feat/recruit post/16 : 구인글 API 구현 

### DIFF
--- a/src/main/java/org/cobee/server/global/error/code/ErrorCode.java
+++ b/src/main/java/org/cobee/server/global/error/code/ErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH-001", "Unauthorized access");
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH-001", "Unauthorized access"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH-002", "Cannot find Member");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/org/cobee/server/global/error/code/ErrorCode.java
+++ b/src/main/java/org/cobee/server/global/error/code/ErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH-001", "Unauthorized access"),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH-002", "Cannot find Member");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH-002", "Cannot find Member"),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST-001", "Cannot find RecruitPost");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/org/cobee/server/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/cobee/server/global/error/handler/GlobalExceptionHandler.java
@@ -12,16 +12,25 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     // CustomException 처리
+//    @ExceptionHandler(CustomException.class)
+//    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException ex) {
+//        ErrorCode errorCode = ex.getErrorCode();
+//        return ResponseEntity
+//                .status(errorCode.getStatus())
+//                .body(ApiResponse.failure(
+//                        errorCode.getMessage(),
+//                        errorCode.getCode(),
+//                        ex.getMessage()
+//                ));
+//    }
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException ex) {
+    public ApiResponse<Void> handleCustomException(CustomException ex) {
         ErrorCode errorCode = ex.getErrorCode();
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ApiResponse.failure(
-                        errorCode.getMessage(),
-                        errorCode.getCode(),
-                        ex.getMessage()
-                ));
+        return ApiResponse.failure(
+                errorCode.getMessage(),
+                errorCode.getCode(),
+                ex.getMessage()
+        );
     }
 
     // 서버 내부 오류 처리

--- a/src/main/java/org/cobee/server/global/response/ApiResponse.java
+++ b/src/main/java/org/cobee/server/global/response/ApiResponse.java
@@ -30,8 +30,13 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, message, code, null, null);
     }
 
-    // 실패 응답
+    // 실패 응답 (데이터 없음)
     public static <T> ApiResponse<T> failure(String message, String code, String error) {
         return new ApiResponse<>(false, message, code, error, null);
+    }
+
+    // 실패 응답 (데이터 포함)
+    public static <T> ApiResponse<T> failure(String message, String code, String error, T data) {
+        return new ApiResponse<>(false, message, code, error, data);
     }
 }

--- a/src/main/java/org/cobee/server/member/domain/Member.java
+++ b/src/main/java/org/cobee/server/member/domain/Member.java
@@ -42,6 +42,9 @@ public class Member {
     private SocialType socialType;
 
     @Column
+    private String profileUrl;
+
+    @Column
     private Boolean ocrValidation;
 
     @Column

--- a/src/main/java/org/cobee/server/recruit/controller/RecruitController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/RecruitController.java
@@ -1,6 +1,7 @@
 package org.cobee.server.recruit.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.cobee.server.global.error.code.ErrorCode;
 import org.cobee.server.global.response.ApiResponse;
 import org.cobee.server.recruit.dto.RecruitRequest;
 import org.cobee.server.recruit.dto.RecruitResponse;
@@ -36,5 +37,15 @@ public class RecruitController {
     public ApiResponse<List<RecruitResponse>> getRecruitPosts(){
         List<RecruitResponse> result = recruitService.getAllRecruitPosts();
         return ApiResponse.success("모든 구인글 조회 완료","RECRUIT_GET_ALL",result);
+    }
+
+    @DeleteMapping("/recruits/{postId}")
+    public ApiResponse<Boolean> deleteRecruitPost(@PathVariable(name="postId") Long postId){
+        Boolean result = recruitService.deleteRecruitPost(postId);
+        if (result) {
+            return ApiResponse.success("postId가 "+postId+"인 구인글 삭제 완료", "RECRUIT_DELETED", result);
+        } else {
+            return ApiResponse.failure("postId가 "+postId+"인 구인글 삭제 실패", "RECRUIT_DELETED_FAILED", ErrorCode.POST_NOT_FOUND.getMessage(), result);
+        }
     }
 }

--- a/src/main/java/org/cobee/server/recruit/controller/RecruitController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/RecruitController.java
@@ -1,9 +1,23 @@
 package org.cobee.server.recruit.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.cobee.server.global.response.ApiResponse;
+import org.cobee.server.recruit.dto.RecruitRequest;
+import org.cobee.server.recruit.dto.RecruitResponse;
+import org.cobee.server.recruit.service.RecruitService;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class RecruitController {
+
+    private final RecruitService recruitService;
+    @PostMapping("/recruits/{memberId}")
+    public ApiResponse<RecruitResponse> createRecruitPost(@RequestBody RecruitRequest request, @PathVariable(name="memberId") Long memberId){
+        RecruitResponse result = recruitService.createRecruitPost(request, memberId);
+        return ApiResponse.success("구인글 생성 완료", "RECRUIT_CREATED", result);
+    }
 }

--- a/src/main/java/org/cobee/server/recruit/controller/RecruitController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/RecruitController.java
@@ -12,34 +12,35 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/recruits")
 public class RecruitController {
 
     private final RecruitService recruitService;
-    @PostMapping("/recruits/{memberId}")
+    @PostMapping("/{memberId}")
     public ApiResponse<RecruitResponse> createRecruitPost(@RequestBody RecruitRequest request, @PathVariable(name="memberId") Long memberId){
         RecruitResponse result = recruitService.createRecruitPost(request, memberId);
         return ApiResponse.success("구인글 생성 완료", "RECRUIT_CREATED", result);
     }
 
-    @PutMapping("/recruits/{memberId}/{postId}")
+    @PutMapping("/{memberId}/{postId}")
     public ApiResponse<RecruitResponse> updateRecruitPost(@RequestBody RecruitRequest request, @PathVariable(name="memberId") Long memberId, @PathVariable(name="postId") Long postId){
         RecruitResponse result = recruitService.updateRecruitPost(request,postId,memberId);
         return ApiResponse.success("구인글 수정 완료", "RECRUIT_UPDATED", result);
     }
 
-    @GetMapping("/recruits/{postId}")
+    @GetMapping("/{postId}")
     public ApiResponse<RecruitResponse> getRecruitPost(@PathVariable(name="postId") Long postId){
         RecruitResponse result = recruitService.getRecruitPost(postId);
         return ApiResponse.success("postId가 "+postId+"인 post 조회 완료", "RECRUIT_GET_ONE", result);
     }
 
-    @GetMapping("/recruits")
+    @GetMapping("")
     public ApiResponse<List<RecruitResponse>> getRecruitPosts(){
         List<RecruitResponse> result = recruitService.getAllRecruitPosts();
         return ApiResponse.success("모든 구인글 조회 완료","RECRUIT_GET_ALL",result);
     }
 
-    @DeleteMapping("/recruits/{postId}")
+    @DeleteMapping("/{postId}")
     public ApiResponse<Boolean> deleteRecruitPost(@PathVariable(name="postId") Long postId){
         Boolean result = recruitService.deleteRecruitPost(postId);
         if (result) {

--- a/src/main/java/org/cobee/server/recruit/controller/RecruitController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/RecruitController.java
@@ -23,4 +23,10 @@ public class RecruitController {
         RecruitResponse result = recruitService.updateRecruitPost(request,postId,memberId);
         return ApiResponse.success("구인글 수정 완료", "RECRUIT_UPDATED", result);
     }
+
+    @GetMapping("/recruits/{postId}")
+    public ApiResponse<RecruitResponse> getRecruitPost(@PathVariable(name="postId") Long postId){
+        RecruitResponse result = recruitService.getRecruitPost(postId);
+        return ApiResponse.success("postId가 "+postId+"인 post 조회 완료", "RECRUIT_GET_ONE", result);
+    }
 }

--- a/src/main/java/org/cobee/server/recruit/controller/RecruitController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/RecruitController.java
@@ -7,6 +7,8 @@ import org.cobee.server.recruit.dto.RecruitResponse;
 import org.cobee.server.recruit.service.RecruitService;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 public class RecruitController {
@@ -28,5 +30,11 @@ public class RecruitController {
     public ApiResponse<RecruitResponse> getRecruitPost(@PathVariable(name="postId") Long postId){
         RecruitResponse result = recruitService.getRecruitPost(postId);
         return ApiResponse.success("postId가 "+postId+"인 post 조회 완료", "RECRUIT_GET_ONE", result);
+    }
+
+    @GetMapping("/recruits")
+    public ApiResponse<List<RecruitResponse>> getRecruitPosts(){
+        List<RecruitResponse> result = recruitService.getAllRecruitPosts();
+        return ApiResponse.success("모든 구인글 조회 완료","RECRUIT_GET_ALL",result);
     }
 }

--- a/src/main/java/org/cobee/server/recruit/controller/RecruitController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/RecruitController.java
@@ -5,10 +5,7 @@ import org.cobee.server.global.response.ApiResponse;
 import org.cobee.server.recruit.dto.RecruitRequest;
 import org.cobee.server.recruit.dto.RecruitResponse;
 import org.cobee.server.recruit.service.RecruitService;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,5 +16,11 @@ public class RecruitController {
     public ApiResponse<RecruitResponse> createRecruitPost(@RequestBody RecruitRequest request, @PathVariable(name="memberId") Long memberId){
         RecruitResponse result = recruitService.createRecruitPost(request, memberId);
         return ApiResponse.success("구인글 생성 완료", "RECRUIT_CREATED", result);
+    }
+
+    @PutMapping("/recruits/{memberId}/{postId}")
+    public ApiResponse<RecruitResponse> updateRecruitPost(@RequestBody RecruitRequest request, @PathVariable(name="memberId") Long memberId, @PathVariable(name="postId") Long postId){
+        RecruitResponse result = recruitService.updateRecruitPost(request,postId,memberId);
+        return ApiResponse.success("구인글 수정 완료", "RECRUIT_UPDATED", result);
     }
 }

--- a/src/main/java/org/cobee/server/recruit/domain/RecruitPost.java
+++ b/src/main/java/org/cobee/server/recruit/domain/RecruitPost.java
@@ -11,6 +11,7 @@ import org.cobee.server.recruit.domain.enums.RecruitStatus;
 import org.cobee.server.chat.domain.ChattingRoom;
 import org.cobee.server.comment.domain.Comment;
 import org.cobee.server.member.domain.Member;
+import org.cobee.server.recruit.dto.RecruitRequest;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -91,5 +92,12 @@ public class RecruitPost {
     private Member member;
 
 
-
+    public void updatePost(RecruitRequest dto) {
+        this.title = dto.title();
+        this.recruitCount = dto.recruitCount();
+        this.rentCost = dto.rentCost();
+        this.monthlyCost = dto.monthlyCost();
+        //this.imgUrl = dto.imgUrl();
+        this.content = dto.content();
+    }
 }

--- a/src/main/java/org/cobee/server/recruit/domain/RecruitPost.java
+++ b/src/main/java/org/cobee/server/recruit/domain/RecruitPost.java
@@ -41,6 +41,9 @@ public class RecruitPost {
     private int rentCost;
 
     @Column
+    private int monthlyCost;
+
+    @Column
     private Float regionLatitude; // 위도
 
     @Column

--- a/src/main/java/org/cobee/server/recruit/domain/RecruitPost.java
+++ b/src/main/java/org/cobee/server/recruit/domain/RecruitPost.java
@@ -2,6 +2,7 @@ package org.cobee.server.recruit.domain;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cobee.server.publicProfile.domain.enums.Lifestyle;
@@ -18,6 +19,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Builder
 public class RecruitPost {
 
     @Id

--- a/src/main/java/org/cobee/server/recruit/dto/RecruitRequest.java
+++ b/src/main/java/org/cobee/server/recruit/dto/RecruitRequest.java
@@ -1,4 +1,5 @@
 package org.cobee.server.recruit.dto;
 
-public class RecruitRequest {
-}
+public record RecruitRequest
+        (String title, int recruitCount, int rentCost,
+         int monthlyCost, String imgUrl, String content) { }

--- a/src/main/java/org/cobee/server/recruit/dto/RecruitResponse.java
+++ b/src/main/java/org/cobee/server/recruit/dto/RecruitResponse.java
@@ -5,13 +5,14 @@ import org.cobee.server.member.domain.Member;
 import org.cobee.server.recruit.domain.RecruitPost;
 @Builder
 public record RecruitResponse(
-        String authorName, Float location /* 이거 어케 처리할지 고민 */, String profileUrl,
+        Long id, String authorName, Float location /* 이거 어케 처리할지 고민 */, String profileUrl,
         String title, int recruitCount, int rentalCost, int monthlyCost,
         String content //String formUrl
 ) {
 
     public static RecruitResponse from(RecruitPost post, Member member) {
         return RecruitResponse.builder()
+                .id(post.getId())
                 .authorName(member.getName())
                 .location(post.getDistance())
                 .profileUrl(member.getProfileUrl())

--- a/src/main/java/org/cobee/server/recruit/dto/RecruitResponse.java
+++ b/src/main/java/org/cobee/server/recruit/dto/RecruitResponse.java
@@ -1,0 +1,26 @@
+package org.cobee.server.recruit.dto;
+
+import lombok.Builder;
+import org.cobee.server.member.domain.Member;
+import org.cobee.server.recruit.domain.RecruitPost;
+@Builder
+public record RecruitResponse(
+        String authorName, Float location /* 이거 어케 처리할지 고민 */, String profileUrl,
+        String title, int recruitCount, int rentalCost, int monthlyCost,
+        String content //String formUrl
+) {
+
+    public static RecruitResponse from(RecruitPost post, Member member) {
+        return RecruitResponse.builder()
+                .authorName(member.getName())
+                .location(post.getDistance())
+                .profileUrl(member.getProfileUrl())
+                .title(post.getTitle())
+                .recruitCount(post.getRecruitCount())
+                .rentalCost(post.getRentCost())
+                .monthlyCost(post.getMonthlyCost())
+                .content(post.getContent())
+                .build();
+
+    }
+}

--- a/src/main/java/org/cobee/server/recruit/service/RecruitService.java
+++ b/src/main/java/org/cobee/server/recruit/service/RecruitService.java
@@ -21,6 +21,7 @@ public class RecruitService {
     private final MemberRepository memberRepository;
 
     public RecruitResponse createRecruitPost(RecruitRequest request, Long memberId){
+        Member member = memberRepository.findById(memberId).orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
         RecruitPost recruitPost = RecruitPost.builder()
                 .title(request.title())
                 .content(request.content())
@@ -38,10 +39,11 @@ public class RecruitService {
                 //.isSmoking()
                 //.personality()
                 //.lifeStyle()
+                .member(member)
                 .build();
         recruitRepository.save(recruitPost);
 
-        Member member = memberRepository.findById(memberId).orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
+
         return RecruitResponse.from(recruitPost, member);
     }
 
@@ -50,6 +52,12 @@ public class RecruitService {
         Member member = memberRepository.findById(memberId).orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
         post.updatePost(request);
         recruitRepository.save(post);
+        return RecruitResponse.from(post, member);
+    }
+
+    public RecruitResponse getRecruitPost(Long postId) {
+        RecruitPost post = recruitRepository.findById(postId).orElseThrow(()->new CustomException(ErrorCode.POST_NOT_FOUND));
+        Member member = post.getMember();
         return RecruitResponse.from(post, member);
     }
 }

--- a/src/main/java/org/cobee/server/recruit/service/RecruitService.java
+++ b/src/main/java/org/cobee/server/recruit/service/RecruitService.java
@@ -1,9 +1,47 @@
 package org.cobee.server.recruit.service;
 
 import lombok.RequiredArgsConstructor;
+import org.cobee.server.global.error.code.ErrorCode;
+import org.cobee.server.global.error.exception.CustomException;
+import org.cobee.server.member.domain.Member;
+import org.cobee.server.member.repository.MemberRepository;
+import org.cobee.server.recruit.domain.RecruitPost;
+import org.cobee.server.recruit.domain.enums.RecruitStatus;
+import org.cobee.server.recruit.dto.RecruitRequest;
+import org.cobee.server.recruit.dto.RecruitResponse;
+import org.cobee.server.recruit.repository.RecruitPostRepository;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class RecruitService {
+    private final RecruitPostRepository recruitRepository;
+    private final MemberRepository memberRepository;
+
+    public RecruitResponse createRecruitPost(RecruitRequest request, Long memberId){
+        RecruitPost recruitPost = RecruitPost.builder()
+                .title(request.title())
+                .content(request.content())
+                .recruitCount(request.recruitCount())
+                .status(RecruitStatus.RECRUITING)
+                .rentCost(request.rentCost())
+                .monthlyCost(request.monthlyCost())
+                //.regionLatitude
+                //.regionLongitude
+                .hasRoom(true)
+                //.isPetsAllowed()
+                //.distance()
+                .createdAt(LocalDateTime.now())
+                //.isSnoring()
+                //.isSmoking()
+                //.personality()
+                //.lifeStyle()
+                .build();
+        recruitRepository.save(recruitPost);
+
+        Member member = memberRepository.findById(memberId).orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return RecruitResponse.from(recruitPost, member);
+    }
 }

--- a/src/main/java/org/cobee/server/recruit/service/RecruitService.java
+++ b/src/main/java/org/cobee/server/recruit/service/RecruitService.java
@@ -71,4 +71,16 @@ public class RecruitService {
         }
         return result;
     }
+
+    public Boolean deleteRecruitPost(Long postId) {
+        try{
+            RecruitPost post = recruitRepository.findById(postId).orElseThrow(()->new CustomException(ErrorCode.POST_NOT_FOUND));
+            recruitRepository.delete(post);
+            return true;
+        } catch (CustomException e) {
+            return false;
+        }
+
+
+    }
 }

--- a/src/main/java/org/cobee/server/recruit/service/RecruitService.java
+++ b/src/main/java/org/cobee/server/recruit/service/RecruitService.java
@@ -44,4 +44,12 @@ public class RecruitService {
         Member member = memberRepository.findById(memberId).orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
         return RecruitResponse.from(recruitPost, member);
     }
+
+    public RecruitResponse updateRecruitPost(RecruitRequest request, Long postId, Long memberId){
+        RecruitPost post = recruitRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        Member member = memberRepository.findById(memberId).orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
+        post.updatePost(request);
+        recruitRepository.save(post);
+        return RecruitResponse.from(post, member);
+    }
 }

--- a/src/main/java/org/cobee/server/recruit/service/RecruitService.java
+++ b/src/main/java/org/cobee/server/recruit/service/RecruitService.java
@@ -13,6 +13,8 @@ import org.cobee.server.recruit.repository.RecruitPostRepository;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -59,5 +61,14 @@ public class RecruitService {
         RecruitPost post = recruitRepository.findById(postId).orElseThrow(()->new CustomException(ErrorCode.POST_NOT_FOUND));
         Member member = post.getMember();
         return RecruitResponse.from(post, member);
+    }
+
+    public List<RecruitResponse> getAllRecruitPosts() {
+        List<RecruitPost> posts = recruitRepository.findAll();
+        List<RecruitResponse> result = new ArrayList<>();
+        for (RecruitPost post : posts){
+            result.add(RecruitResponse.from(post, post.getMember()));
+        }
+        return result;
     }
 }


### PR DESCRIPTION
### 구인글 API 구현 모두 완료 
- 구인글 생성 
- 구인글 수정
- 구인글 삭제
- 구인글 조회 (단일/모두)
- 그 외 ApiResponse 실패일때도 data 넣을수 있게 메서드 추가 