### PR TITLE
[BE/FEAT] Feat/apply/28 : 지원내역 관련 API 구현 

### DIFF
--- a/src/main/java/org/cobee/server/global/error/code/ErrorCode.java
+++ b/src/main/java/org/cobee/server/global/error/code/ErrorCode.java
@@ -8,7 +8,8 @@ public enum ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH-001", "Unauthorized access"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH-002", "Cannot find Member"),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST-001", "Cannot find RecruitPost"),
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT-001", "Cannot find Comment");
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT-001", "Cannot find Comment"),
+    APPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLY-001", "APPLY find Comment");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/org/cobee/server/publicProfile/domain/PublicProfile.java
+++ b/src/main/java/org/cobee/server/publicProfile/domain/PublicProfile.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.cobee.server.member.domain.Member;
 import org.cobee.server.publicProfile.domain.enums.Lifestyle;
 import org.cobee.server.publicProfile.domain.enums.Personality;
 

--- a/src/main/java/org/cobee/server/publicProfile/dto/PublicProfileResponseDto.java
+++ b/src/main/java/org/cobee/server/publicProfile/dto/PublicProfileResponseDto.java
@@ -1,5 +1,7 @@
 package org.cobee.server.publicProfile.dto;
 
+import org.cobee.server.member.domain.Member;
+import org.cobee.server.publicProfile.domain.PublicProfile;
 import org.cobee.server.publicProfile.domain.enums.Lifestyle;
 import org.cobee.server.publicProfile.domain.enums.Personality;
 
@@ -14,4 +16,17 @@ public record PublicProfileResponseDto(
         Boolean mSnoring,
         Boolean mPet
 ) {
+    public static PublicProfileResponseDto from(PublicProfile publicProfile, Member member){
+        return new PublicProfileResponseDto(
+                member.getId(),
+                member.getName(),
+                member.getGender(),
+                publicProfile.getInfo(),
+                publicProfile.getLifestyle(),
+                publicProfile.getPersonality(),
+                publicProfile.getIsSmoking(),
+                publicProfile.getIsSnoring(),
+                publicProfile.getHasPet()
+        );
+    }
 }

--- a/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
@@ -1,0 +1,22 @@
+package org.cobee.server.recruit.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.cobee.server.global.response.ApiResponse;
+import org.cobee.server.recruit.dto.ApplyRequest;
+import org.cobee.server.recruit.dto.ApplyResponse;
+import org.cobee.server.recruit.service.ApplyService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/apply")
+public class ApplyController {
+    private final ApplyService applyService;
+    @PostMapping("/{fromMemberId}")
+    public ApiResponse<ApplyResponse> applyForRecruit(@PathVariable(name="fromMemberId") Long memberId,
+                                                      @RequestBody ApplyRequest request){
+        ApplyResponse result = applyService.apply(memberId, request);
+        return ApiResponse.success("", "", result);
+
+    }
+}

--- a/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
@@ -45,8 +45,8 @@ public class ApplyController {
 
     }
 
-    // MatchStatus가 NONE인 것들(지원 중)
-    @GetMapping("/my")
+    // MatchStatus가 ON_WAIT인 것들(지원 중)
+    @GetMapping("/my/onWait")
     public ApiResponse<List<RecruitResponse>> myAppliedPost(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         // 현재 로그인 사용자
         Long memberId = principalDetails.getMember().getId();
@@ -55,7 +55,13 @@ public class ApplyController {
     }
 
     // isMatched MATCHING로 된 구인글 리스트 조회 <= 작성자가 승인 버튼 눌러서 채팅에 초대 알림 보낸 구인글 탭
-
+    @GetMapping("/my/matching")
+    public ApiResponse<List<RecruitResponse>> myOnMatchingPost(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        // 현재 로그인 사용자
+        Long memberId = principalDetails.getMember().getId();
+        List<RecruitResponse> myApplies = applyService.getMyAppliesOnMatching(memberId);
+        return ApiResponse.success("나의 지원 구인글 목록 조회 완료", "APPLY-004", myApplies);
+    }
 
 
     // isMatched가 Matched인 구인글 보기
@@ -69,7 +75,7 @@ public class ApplyController {
     {
         try{
             Long memberId = principalDetails.getMember().getId();
-            List<PublicProfileResponseDto> result = applyService.getMyAppliers(postId, memberId);
+            List<PublicProfileResponseDto> result = applyService.getMyPostAppliers(postId, memberId);
             if (result.isEmpty()) {
                 return ApiResponse.success("지원한 멤버가 없습니다.", "", result);
             }

--- a/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
@@ -1,12 +1,18 @@
 package org.cobee.server.recruit.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.cobee.server.auth.service.PrincipalDetails;
 import org.cobee.server.global.response.ApiResponse;
+import org.cobee.server.recruit.domain.ApplyRecord;
 import org.cobee.server.recruit.dto.ApplyAcceptRequest;
 import org.cobee.server.recruit.dto.ApplyRequest;
 import org.cobee.server.recruit.dto.ApplyResponse;
+import org.cobee.server.recruit.dto.RecruitResponse;
 import org.cobee.server.recruit.service.ApplyService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,4 +37,14 @@ public class ApplyController {
             return ApiResponse.success("매칭이 거절되었습니다", "APPLY-003", result);
         }
     }
+
+    @GetMapping("/my")
+    public ApiResponse<List<RecruitResponse>> myAppliedPost(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        // 현재 로그인 사용자
+        Long memberId = principalDetails.getMember().getId();
+        List<RecruitResponse> myApplies = applyService.getMyApplies(memberId);
+        return ApiResponse.success("나의 지원 구인글 목룍 조회 완료", "APPLY-004", myApplies);
+    }
+
+
 }

--- a/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
@@ -83,7 +83,7 @@ public class ApplyController {
     {
         try{
             Long memberId = principalDetails.getMember().getId();
-            List<PublicProfileResponseDto> result = applyService.getMyPostAppliers(postId, memberId);
+            List<PublicProfileResponseDto> result = applyService.getMyAllPostAppliers(postId, memberId);
             if (result.isEmpty()) {
                 return ApiResponse.success("지원한 멤버가 없습니다.", "APPLY-007", result);
             }
@@ -92,6 +92,7 @@ public class ApplyController {
             return ApiResponse.failure("정보 요청을 다시 해주세요","APPLY-009",e.getMessage());
         }
     }
+
 
 
 }

--- a/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
@@ -20,20 +20,23 @@ import java.util.List;
 @RequestMapping("/apply")
 public class ApplyController {
     private final ApplyService applyService;
-    @PostMapping("/{fromMemberId}")
-    public ApiResponse<ApplyResponse> applyForRecruit(@PathVariable(name="fromMemberId") Long memberId,
+    @PostMapping()
+    public ApiResponse<ApplyResponse> applyForRecruit(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                       @RequestBody ApplyRequest request){
+        Long memberId = principalDetails.getMember().getId();
         ApplyResponse result = applyService.apply(memberId, request);
         return ApiResponse.success("지원이 완료되었습니다", "APPLY-001", result);
 
     }
 
-    // 매칭 승인이 되면 Matching으로 바꾸기 (현재는 Matched로 되어있음) (== 채팅방 초대 => 초대된 구인글 리스트에도 보이게 추가하기)
-    @PostMapping("/accept/{applyId}")  // 글쓴이와 현재로그인한 사람 같은지 비교 안해도 되려나? 지원목록만 쓴 글이 있을때 보여줌 돼
+    // 매칭 승인이 되면 Matching으로 바꾸기 : 이때 채팅방 초대 알림 및 매칭 알림 보내기
+    @PostMapping("/accept/{applyId}")
     public ApiResponse<ApplyResponse> acceptApply(@PathVariable(name="applyId") Long applyId,
-                                                  @RequestBody ApplyAcceptRequest request){
+                                                  @RequestBody ApplyAcceptRequest request,
+                                                  @AuthenticationPrincipal PrincipalDetails principalDetails){
         try {
-            ApplyResponse result = applyService.accept(applyId, request);
+            Long memberId = principalDetails.getMember().getId();
+            ApplyResponse result = applyService.accept(memberId, applyId, request);
             if (request.getIsAccept()){
                 return ApiResponse.success("매칭이 되었습니다.", "APPLY-002", result);
             } else {

--- a/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
@@ -5,7 +5,6 @@ import org.cobee.server.auth.service.PrincipalDetails;
 import org.cobee.server.global.error.exception.CustomException;
 import org.cobee.server.global.response.ApiResponse;
 import org.cobee.server.publicProfile.dto.PublicProfileResponseDto;
-import org.cobee.server.recruit.domain.ApplyRecord;
 import org.cobee.server.recruit.dto.ApplyAcceptRequest;
 import org.cobee.server.recruit.dto.ApplyRequest;
 import org.cobee.server.recruit.dto.ApplyResponse;
@@ -51,7 +50,7 @@ public class ApplyController {
     public ApiResponse<List<RecruitResponse>> myAppliedPost(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         // 현재 로그인 사용자
         Long memberId = principalDetails.getMember().getId();
-        List<RecruitResponse> myApplies = applyService.getMyApplies(memberId);
+        List<RecruitResponse> myApplies = applyService.getMyAppliesOnWait(memberId);
         return ApiResponse.success("나의 지원 구인글 목록 조회 완료", "APPLY-004", myApplies);
     }
 

--- a/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
@@ -2,6 +2,7 @@ package org.cobee.server.recruit.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.cobee.server.global.response.ApiResponse;
+import org.cobee.server.recruit.dto.ApplyAcceptRequest;
 import org.cobee.server.recruit.dto.ApplyRequest;
 import org.cobee.server.recruit.dto.ApplyResponse;
 import org.cobee.server.recruit.service.ApplyService;
@@ -18,5 +19,12 @@ public class ApplyController {
         ApplyResponse result = applyService.apply(memberId, request);
         return ApiResponse.success("지원이 완료되었습니다", "APPLY-001", result);
 
+    }
+
+    @PostMapping("/accept/{applyId}")  // 글쓴이와 현재로그인한 사람 같은지 비교 안해도 되려나? 지원목록만 쓴 글이 있을때 보여줌 돼
+    public ApiResponse<ApplyResponse> acceptApply(@PathVariable(name="applyId") Long applyId,
+                                                  @RequestBody ApplyAcceptRequest request){
+        ApplyResponse result = applyService.accept(applyId, request);
+        return ApiResponse.success("매칭이 되었습니다.", "APPLY-002", result);
     }
 }

--- a/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
@@ -33,12 +33,17 @@ public class ApplyController {
     @PostMapping("/accept/{applyId}")  // 글쓴이와 현재로그인한 사람 같은지 비교 안해도 되려나? 지원목록만 쓴 글이 있을때 보여줌 돼
     public ApiResponse<ApplyResponse> acceptApply(@PathVariable(name="applyId") Long applyId,
                                                   @RequestBody ApplyAcceptRequest request){
-        ApplyResponse result = applyService.accept(applyId, request);
-        if (request.getIsAccept()){
-            return ApiResponse.success("매칭이 되었습니다.", "APPLY-002", result);
-        } else {
-            return ApiResponse.success("매칭이 거절되었습니다", "APPLY-003", result);
+        try {
+            ApplyResponse result = applyService.accept(applyId, request);
+            if (request.getIsAccept()){
+                return ApiResponse.success("매칭이 되었습니다.", "APPLY-002", result);
+            } else {
+                return ApiResponse.success("매칭이 거절되었습니다", "APPLY-003", result);
+            }
+        } catch (CustomException e){
+            return ApiResponse.failure("", "", e.getMessage());
         }
+
     }
 
     @GetMapping("/my")
@@ -46,13 +51,15 @@ public class ApplyController {
         // 현재 로그인 사용자
         Long memberId = principalDetails.getMember().getId();
         List<RecruitResponse> myApplies = applyService.getMyApplies(memberId);
-        return ApiResponse.success("나의 지원 구인글 목룍 조회 완료", "APPLY-004", myApplies);
+        return ApiResponse.success("나의 지원 구인글 목록 조회 완료", "APPLY-004", myApplies);
     }
 
     // 나의 특정 구인글에 지원한 지원자 내역
+    // TODO : 멤버 처리 어떻게 할지, 고민
     @GetMapping("/{postId}")
     public ApiResponse<List<PublicProfileResponseDto>> myAppliers(@PathVariable(name="postId") Long postId,
-                                                                  @AuthenticationPrincipal PrincipalDetails principalDetails){
+                                                                  @AuthenticationPrincipal PrincipalDetails principalDetails)
+    {
         try{
             Long memberId = principalDetails.getMember().getId();
             List<PublicProfileResponseDto> result = applyService.getMyAppliers(postId, memberId);

--- a/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
@@ -46,6 +46,7 @@ public class ApplyController {
 
     }
 
+    // MatchStatus가 NONE인 것들(지원 중)
     @GetMapping("/my")
     public ApiResponse<List<RecruitResponse>> myAppliedPost(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         // 현재 로그인 사용자
@@ -53,6 +54,13 @@ public class ApplyController {
         List<RecruitResponse> myApplies = applyService.getMyApplies(memberId);
         return ApiResponse.success("나의 지원 구인글 목록 조회 완료", "APPLY-004", myApplies);
     }
+
+    // isMatched MATCHING로 된 구인글 리스트 조회 <= 작성자가 승인 버튼 눌러서 채팅에 초대 알림 보낸 구인글 탭
+
+
+
+    // isMatched가 Matched인 구인글 보기
+
 
     // 나의 특정 구인글에 지원한 지원자 내역
     // TODO : 멤버 처리 어떻게 할지, 고민
@@ -72,5 +80,5 @@ public class ApplyController {
         }
     }
 
-    // isMatched true인 사람은 초대된 구인글 리스트 보이게 추가하기
+
 }

--- a/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
@@ -38,12 +38,12 @@ public class ApplyController {
             Long memberId = principalDetails.getMember().getId();
             ApplyResponse result = applyService.accept(memberId, applyId, request);
             if (request.getIsAccept()){
-                return ApiResponse.success("매칭이 되었습니다.", "APPLY-002", result);
+                return ApiResponse.success("매칭이 성사되었습니다.", "APPLY-002", result);
             } else {
                 return ApiResponse.success("매칭이 거절되었습니다", "APPLY-003", result);
             }
         } catch (CustomException e){
-            return ApiResponse.failure("", "", e.getMessage());
+            return ApiResponse.failure("입력한 정보를 다시 한 번 더 확인해주세요", "APPLY-002-1a", e.getMessage());
         }
 
     }
@@ -76,9 +76,8 @@ public class ApplyController {
 
 
     // 나의 특정 구인글에 지원한 지원자 공개프로필 리스트
-    // TODO : 멤버 처리 어떻게 할지, 고민
-    @GetMapping("/{postId}")
-    public ApiResponse<List<PublicProfileResponseDto>> myAppliers(@PathVariable(name="postId") Long postId,
+    @GetMapping("/{postId}/all")
+    public ApiResponse<List<PublicProfileResponseDto>> myAllAppliers(@PathVariable(name="postId") Long postId,
                                                                   @AuthenticationPrincipal PrincipalDetails principalDetails)
     {
         try{
@@ -90,6 +89,54 @@ public class ApplyController {
             return ApiResponse.success("지원자 조회 성공", "APPLY-008", result);
         } catch (CustomException e){
             return ApiResponse.failure("정보 요청을 다시 해주세요","APPLY-009",e.getMessage());
+        }
+    }
+
+    @GetMapping("/{postId}/onWait")
+    public ApiResponse<List<PublicProfileResponseDto>> myOnConsideredAppliers(@PathVariable(name="postId") Long postId,
+                                                                     @AuthenticationPrincipal PrincipalDetails principalDetails)
+    {
+        try{
+            Long memberId = principalDetails.getMember().getId();
+            List<PublicProfileResponseDto> result = applyService.getMyOnConsideredPostAppliers(postId, memberId);
+            if (result.isEmpty()) {
+                return ApiResponse.success("지원한 멤버가 없습니다.", "APPLY-010", result);
+            }
+            return ApiResponse.success("지원자 조회 성공", "APPLY-011", result);
+        } catch (CustomException e){
+            return ApiResponse.failure("정보 요청을 다시 해주세요","APPLY-012",e.getMessage());
+        }
+    }
+
+    @GetMapping("/{postId}/approve")
+    public ApiResponse<List<PublicProfileResponseDto>> myOnApprovedAppliers(@PathVariable(name="postId") Long postId,
+                                                                              @AuthenticationPrincipal PrincipalDetails principalDetails)
+    {
+        try{
+            Long memberId = principalDetails.getMember().getId();
+            List<PublicProfileResponseDto> result = applyService.getMyOnApprovedPostAppliers(postId, memberId);
+            if (result.isEmpty()) {
+                return ApiResponse.success("지원한 멤버가 없습니다.", "APPLY-013", result);
+            }
+            return ApiResponse.success("지원자 조회 성공", "APPLY-014", result);
+        } catch (CustomException e){
+            return ApiResponse.failure("정보 요청을 다시 해주세요","APPLY-015",e.getMessage());
+        }
+    }
+
+    @GetMapping("/{postId}/reject")
+    public ApiResponse<List<PublicProfileResponseDto>> myRejectedAppliers(@PathVariable(name="postId") Long postId,
+                                                                            @AuthenticationPrincipal PrincipalDetails principalDetails)
+    {
+        try{
+            Long memberId = principalDetails.getMember().getId();
+            List<PublicProfileResponseDto> result = applyService.getMyRejectedPostAppliers(postId, memberId);
+            if (result.isEmpty()) {
+                return ApiResponse.success("지원한 멤버가 없습니다.", "APPLY-016", result);
+            }
+            return ApiResponse.success("지원자 조회 성공", "APPLY-017", result);
+        } catch (CustomException e){
+            return ApiResponse.failure("정보 요청을 다시 해주세요","APPLY-018",e.getMessage());
         }
     }
 

--- a/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
@@ -54,20 +54,25 @@ public class ApplyController {
         return ApiResponse.success("나의 지원 구인글 목록 조회 완료", "APPLY-004", myApplies);
     }
 
-    // isMatched MATCHING로 된 구인글 리스트 조회 <= 작성자가 승인 버튼 눌러서 채팅에 초대 알림 보낸 구인글 탭
+    // isMatched MATCHING으로 된 구인글 리스트 조회 <= 작성자가 승인 버튼 눌러서 채팅에 초대 알림 보낸 구인글 탭
     @GetMapping("/my/matching")
     public ApiResponse<List<RecruitResponse>> myOnMatchingPost(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         // 현재 로그인 사용자
         Long memberId = principalDetails.getMember().getId();
         List<RecruitResponse> myApplies = applyService.getMyAppliesOnMatching(memberId);
-        return ApiResponse.success("나의 지원 구인글 목록 조회 완료", "APPLY-004", myApplies);
+        return ApiResponse.success("나의 지원 구인글 목록 조회 완료", "APPLY-005", myApplies);
+    }
+
+    // isMatched가 MATCHED인 구인글 보기
+    @GetMapping("/my/matched")
+    public ApiResponse<List<RecruitResponse>> myMatchedPost(@AuthenticationPrincipal PrincipalDetails principalDetails){
+        Long memberId = principalDetails.getMember().getId();
+        List<RecruitResponse> myApplies = applyService.getMyAppliesOnMatched(memberId);
+        return ApiResponse.success("나의 매칭된 구인글 목록 조회 완료", "APPLY-006", myApplies);
     }
 
 
-    // isMatched가 Matched인 구인글 보기
-
-
-    // 나의 특정 구인글에 지원한 지원자 내역
+    // 나의 특정 구인글에 지원한 지원자 공개프로필 리스트
     // TODO : 멤버 처리 어떻게 할지, 고민
     @GetMapping("/{postId}")
     public ApiResponse<List<PublicProfileResponseDto>> myAppliers(@PathVariable(name="postId") Long postId,
@@ -77,11 +82,11 @@ public class ApplyController {
             Long memberId = principalDetails.getMember().getId();
             List<PublicProfileResponseDto> result = applyService.getMyPostAppliers(postId, memberId);
             if (result.isEmpty()) {
-                return ApiResponse.success("지원한 멤버가 없습니다.", "", result);
+                return ApiResponse.success("지원한 멤버가 없습니다.", "APPLY-007", result);
             }
-            return ApiResponse.success("지원자 조회 성공", "", result);
+            return ApiResponse.success("지원자 조회 성공", "APPLY-008", result);
         } catch (CustomException e){
-            return ApiResponse.failure("정보 요청을 다시 해주세요","",e.getMessage());
+            return ApiResponse.failure("정보 요청을 다시 해주세요","APPLY-009",e.getMessage());
         }
     }
 

--- a/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
@@ -16,7 +16,7 @@ public class ApplyController {
     public ApiResponse<ApplyResponse> applyForRecruit(@PathVariable(name="fromMemberId") Long memberId,
                                                       @RequestBody ApplyRequest request){
         ApplyResponse result = applyService.apply(memberId, request);
-        return ApiResponse.success("", "", result);
+        return ApiResponse.success("지원이 완료되었습니다", "APPLY-001", result);
 
     }
 }

--- a/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
+++ b/src/main/java/org/cobee/server/recruit/controller/ApplyController.java
@@ -25,6 +25,10 @@ public class ApplyController {
     public ApiResponse<ApplyResponse> acceptApply(@PathVariable(name="applyId") Long applyId,
                                                   @RequestBody ApplyAcceptRequest request){
         ApplyResponse result = applyService.accept(applyId, request);
-        return ApiResponse.success("매칭이 되었습니다.", "APPLY-002", result);
+        if (request.getIsAccept()){
+            return ApiResponse.success("매칭이 되었습니다.", "APPLY-002", result);
+        } else {
+            return ApiResponse.success("매칭이 거절되었습니다", "APPLY-003", result);
+        }
     }
 }

--- a/src/main/java/org/cobee/server/recruit/domain/ApplyRecord.java
+++ b/src/main/java/org/cobee/server/recruit/domain/ApplyRecord.java
@@ -44,4 +44,8 @@ public class ApplyRecord {
     public void setPost(RecruitPost recruitPost) {
         this.post=recruitPost;
     }
+
+    public void acceptMatching(Boolean accept){
+        this.isMatched=accept;
+    }
 }

--- a/src/main/java/org/cobee/server/recruit/domain/ApplyRecord.java
+++ b/src/main/java/org/cobee/server/recruit/domain/ApplyRecord.java
@@ -2,6 +2,7 @@ package org.cobee.server.recruit.domain;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cobee.server.alarm.domain.Alarm;
@@ -14,6 +15,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Builder
 public class ApplyRecord {
 
     @Id
@@ -39,4 +41,7 @@ public class ApplyRecord {
     @JoinColumn(name = "alarm_id")  // FK 열, FK 연결하고 싶은 그 객체 타입을 쓰면 매핑해줌
     private Alarm alarm;
 
+    public void setPost(RecruitPost recruitPost) {
+        this.post=recruitPost;
+    }
 }

--- a/src/main/java/org/cobee/server/recruit/domain/ApplyRecord.java
+++ b/src/main/java/org/cobee/server/recruit/domain/ApplyRecord.java
@@ -48,7 +48,7 @@ public class ApplyRecord {
     }
 
     public void acceptMatching(Boolean accept){
-        if (accept) this.isMatched=MatchStatus.ACCEPTED;
+        if (accept) this.isMatched=MatchStatus.MATCHING;
         else this.isMatched=MatchStatus.REJECTED;
     }
 }

--- a/src/main/java/org/cobee/server/recruit/domain/ApplyRecord.java
+++ b/src/main/java/org/cobee/server/recruit/domain/ApplyRecord.java
@@ -8,6 +8,7 @@ import org.cobee.server.alarm.domain.Alarm;
 import org.cobee.server.member.domain.Member;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 
 @Entity
 @NoArgsConstructor
@@ -20,10 +21,10 @@ public class ApplyRecord {
     private Long id;
 
     @Column
-    private Boolean isMatched;
+    private Boolean isMatched=false;
 
     @Column
-    private Timestamp submittedAt;
+    private LocalDate submittedAt;
 
     @ManyToOne
     @JoinColumn(name = "user_id")

--- a/src/main/java/org/cobee/server/recruit/domain/ApplyRecord.java
+++ b/src/main/java/org/cobee/server/recruit/domain/ApplyRecord.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.cobee.server.alarm.domain.Alarm;
 import org.cobee.server.member.domain.Member;
+import org.cobee.server.recruit.domain.enums.MatchStatus;
 
 import java.sql.Timestamp;
 import java.time.LocalDate;
@@ -23,7 +24,8 @@ public class ApplyRecord {
     private Long id;
 
     @Column
-    private Boolean isMatched=false;
+    @Enumerated(EnumType.STRING)
+    private MatchStatus isMatched;
 
     @Column
     private LocalDate submittedAt;
@@ -46,6 +48,7 @@ public class ApplyRecord {
     }
 
     public void acceptMatching(Boolean accept){
-        this.isMatched=accept;
+        if (accept) this.isMatched=MatchStatus.ACCEPTED;
+        else this.isMatched=MatchStatus.REJECTED;
     }
 }

--- a/src/main/java/org/cobee/server/recruit/domain/RecruitPost.java
+++ b/src/main/java/org/cobee/server/recruit/domain/RecruitPost.java
@@ -14,6 +14,7 @@ import org.cobee.server.member.domain.Member;
 import org.cobee.server.recruit.dto.RecruitRequest;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -84,8 +85,8 @@ public class RecruitPost {
     @OneToOne
     private ChattingRoom chattingRoom;
 
-    @ManyToOne
-    private ApplyRecord applyRecords;
+    @OneToMany(mappedBy = "post")
+    private List<ApplyRecord> applyRecords = new ArrayList<>();
 
     @ManyToOne
     @JoinColumn(name="user_id")
@@ -104,4 +105,10 @@ public class RecruitPost {
     public void addComment(Comment comment) {
         comments.add(comment);
     }
+
+    public void addApply(ApplyRecord apply) {
+        this.applyRecords.add(apply);
+        apply.setPost(this); // FK 가진 소유자 쪽도 세팅
+    }
+
 }

--- a/src/main/java/org/cobee/server/recruit/domain/enums/MatchStatus.java
+++ b/src/main/java/org/cobee/server/recruit/domain/enums/MatchStatus.java
@@ -1,0 +1,5 @@
+package org.cobee.server.recruit.domain.enums;
+
+public enum MatchStatus {
+    NONE, REJECTED, ACCEPTED
+}

--- a/src/main/java/org/cobee/server/recruit/domain/enums/MatchStatus.java
+++ b/src/main/java/org/cobee/server/recruit/domain/enums/MatchStatus.java
@@ -1,5 +1,5 @@
 package org.cobee.server.recruit.domain.enums;
 
 public enum MatchStatus {
-    NONE, REJECTED, ACCEPTED
+    NONE, MATCHING, REJECTED, MATCHED
 }

--- a/src/main/java/org/cobee/server/recruit/domain/enums/MatchStatus.java
+++ b/src/main/java/org/cobee/server/recruit/domain/enums/MatchStatus.java
@@ -1,5 +1,8 @@
 package org.cobee.server.recruit.domain.enums;
 
 public enum MatchStatus {
-    NONE, MATCHING, REJECTED, MATCHED
+    ON_WAIT,     // 지원했을 때 승인 받는거 대기중
+    MATCHING, // 승인 받음
+    REJECTED, // 거절당함
+    MATCHED  // 최종매칭
 }

--- a/src/main/java/org/cobee/server/recruit/dto/ApplyAcceptRequest.java
+++ b/src/main/java/org/cobee/server/recruit/dto/ApplyAcceptRequest.java
@@ -1,0 +1,8 @@
+package org.cobee.server.recruit.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ApplyAcceptRequest {
+    private Boolean isAccept;
+}

--- a/src/main/java/org/cobee/server/recruit/dto/ApplyRequest.java
+++ b/src/main/java/org/cobee/server/recruit/dto/ApplyRequest.java
@@ -1,0 +1,7 @@
+package org.cobee.server.recruit.dto;
+import lombok.Getter;
+
+@Getter
+public class ApplyRequest {
+    private Long postId;
+}

--- a/src/main/java/org/cobee/server/recruit/dto/ApplyResponse.java
+++ b/src/main/java/org/cobee/server/recruit/dto/ApplyResponse.java
@@ -3,6 +3,7 @@ package org.cobee.server.recruit.dto;
 import lombok.Builder;
 import lombok.Getter;
 import org.cobee.server.recruit.domain.ApplyRecord;
+import org.cobee.server.recruit.domain.enums.MatchStatus;
 
 @Builder
 @Getter
@@ -10,7 +11,7 @@ public class ApplyResponse {
     private Long id;
     private Long appliedPostId;
     private Long appliedMemberId;
-    private Boolean isMatched;
+    private MatchStatus isMatched;
 
     public static ApplyResponse from(ApplyRecord apply) {
         return ApplyResponse.builder()

--- a/src/main/java/org/cobee/server/recruit/dto/ApplyResponse.java
+++ b/src/main/java/org/cobee/server/recruit/dto/ApplyResponse.java
@@ -1,0 +1,23 @@
+package org.cobee.server.recruit.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.cobee.server.recruit.domain.ApplyRecord;
+
+@Builder
+@Getter
+public class ApplyResponse {
+    private Long id;
+    private Long appliedPostId;
+    private Long appliedMemberId;
+    private Boolean isMatched;
+
+    public static ApplyResponse from(ApplyRecord apply) {
+        return ApplyResponse.builder()
+                .id(apply.getId())
+                .appliedPostId(apply.getPost().getId())
+                .appliedMemberId(apply.getMember().getId())
+                .isMatched(apply.getIsMatched())
+                .build();
+    }
+}

--- a/src/main/java/org/cobee/server/recruit/dto/RecruitResponse.java
+++ b/src/main/java/org/cobee/server/recruit/dto/RecruitResponse.java
@@ -9,7 +9,11 @@ import org.cobee.server.recruit.domain.RecruitPost;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
+/*
+TODO
+- class로 바꾸기
+- response에 댓글개수, 조회수(가능하면), 지원자 n명 추가
+ */
 @Builder
 public record RecruitResponse(
         Long id, String authorName, Float location /* 이거 어케 처리할지 고민 */, String profileUrl,

--- a/src/main/java/org/cobee/server/recruit/dto/RecruitResponse.java
+++ b/src/main/java/org/cobee/server/recruit/dto/RecruitResponse.java
@@ -16,7 +16,7 @@ TODO
  */
 @Builder
 public record RecruitResponse(
-        Long id, String authorName, Float location /* 이거 어케 처리할지 고민 */, String profileUrl,
+        Long postId, String authorName, Float location /* 이거 어케 처리할지 고민 */, String profileUrl,
         String title, int recruitCount, int rentalCost, int monthlyCost,
         String content //String formUrl
         , List<CommentResponse> comments
@@ -30,10 +30,10 @@ public record RecruitResponse(
         }
 
         return RecruitResponse.builder()
-                .id(post.getId())
-                .authorName(member.getName())
+                .postId(post.getId())
+                .authorName(post.getMember().getName())
                 .location(post.getDistance())
-                .profileUrl(member.getProfileUrl())
+                .profileUrl(post.getMember().getProfileUrl())
                 .title(post.getTitle())
                 .recruitCount(post.getRecruitCount())
                 .rentalCost(post.getRentCost())

--- a/src/main/java/org/cobee/server/recruit/repository/ApplyRecordRepository.java
+++ b/src/main/java/org/cobee/server/recruit/repository/ApplyRecordRepository.java
@@ -2,6 +2,8 @@ package org.cobee.server.recruit.repository;
 
 import org.cobee.server.recruit.domain.ApplyRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,4 +11,6 @@ import java.util.List;
 @Repository
 public interface ApplyRecordRepository extends JpaRepository<ApplyRecord, Long> {
     List<ApplyRecord> findApplyRecordsByMemberId(Long memberId);
+    @Query("select applies from ApplyRecord applies where applies.post.id=:postId")
+    List<ApplyRecord> findMyPostAppliers(@Param("postId") Long postId);
 }

--- a/src/main/java/org/cobee/server/recruit/repository/ApplyRecordRepository.java
+++ b/src/main/java/org/cobee/server/recruit/repository/ApplyRecordRepository.java
@@ -4,6 +4,9 @@ import org.cobee.server.recruit.domain.ApplyRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ApplyRecordRepository extends JpaRepository<ApplyRecord, Long> {
+    List<ApplyRecord> findApplyRecordsByMemberId(Long memberId);
 }

--- a/src/main/java/org/cobee/server/recruit/repository/ApplyRecordRepository.java
+++ b/src/main/java/org/cobee/server/recruit/repository/ApplyRecordRepository.java
@@ -1,6 +1,7 @@
 package org.cobee.server.recruit.repository;
 
 import org.cobee.server.recruit.domain.ApplyRecord;
+import org.cobee.server.recruit.domain.enums.MatchStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,7 +11,17 @@ import java.util.List;
 
 @Repository
 public interface ApplyRecordRepository extends JpaRepository<ApplyRecord, Long> {
-    List<ApplyRecord> findApplyRecordsByMemberId(Long memberId);
-    @Query("select applies from ApplyRecord applies where applies.post.id=:postId")
-    List<ApplyRecord> findMyPostAppliers(@Param("postId") Long postId);
+
+    // 내가 쓴 구인글에 지원한 사람들의 기록 (내 구인글 탭에서 지원자 승인 받는 곳)
+    @Query("select applies from ApplyRecord applies where applies.post.id=:postId and applies.member.id=:memberId")
+    List<ApplyRecord> findMyPostAppliers(@Param("memberId") Long memberId, @Param("postId") Long postId);
+
+    // 내가 지원한 구인글(= ON_WAIT) 가져오기(프론트상 첫번째 탭), MATCHING인 것 status 변수로 가져오기
+    @Query("select applies from ApplyRecord applies where applies.isMatched=:status and applies.member.id=:memberId")
+    List<ApplyRecord> findApplyRecordsByMemberIdAndStatus(@Param("memberId") Long memberId, @Param("status") MatchStatus status);
+
+    // 매칭 완료된 구인글 보기 (MATCHED 상태 - 프론트상 2번쨰 탭)
+
+
+
 }

--- a/src/main/java/org/cobee/server/recruit/repository/ApplyRecordRepository.java
+++ b/src/main/java/org/cobee/server/recruit/repository/ApplyRecordRepository.java
@@ -13,8 +13,8 @@ import java.util.List;
 public interface ApplyRecordRepository extends JpaRepository<ApplyRecord, Long> {
 
     // 내가 쓴 구인글에 지원한 사람들의 기록 (내 구인글 탭에서 지원자 승인 받는 곳)
-    @Query("select applies from ApplyRecord applies where applies.post.id=:postId and applies.member.id=:memberId")
-    List<ApplyRecord> findMyPostAppliers(@Param("memberId") Long memberId, @Param("postId") Long postId);
+    @Query("select applies from ApplyRecord applies where applies.post.id=:postId")
+    List<ApplyRecord> findMyPostAppliers(@Param("postId") Long postId);
 
     // 내가 지원한 구인글(= ON_WAIT) 가져오기(프론트상 첫번째 탭), MATCHING인 것 status 변수로 가져오기
     @Query("select applies from ApplyRecord applies where applies.isMatched=:status and applies.member.id=:memberId")

--- a/src/main/java/org/cobee/server/recruit/repository/ApplyRecordRepository.java
+++ b/src/main/java/org/cobee/server/recruit/repository/ApplyRecordRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Repository
 public interface ApplyRecordRepository extends JpaRepository<ApplyRecord, Long> {
 
-    // 내가 쓴 구인글에 지원한 사람들의 기록 (내 구인글 탭에서 지원자 승인 받는 곳)
+    // 내가 쓴 구인글에 지원한 사람들의 모든 공개프로필 리스트 (조건상관X, 내 구인글 탭에서 지원자 승인 받는 곳)
     @Query("select applies from ApplyRecord applies where applies.post.id=:postId")
     List<ApplyRecord> findMyPostAppliers(@Param("postId") Long postId);
 
@@ -20,6 +20,8 @@ public interface ApplyRecordRepository extends JpaRepository<ApplyRecord, Long> 
     @Query("select applies from ApplyRecord applies where applies.isMatched=:status and applies.member.id=:memberId")
     List<ApplyRecord> findApplyRecordsByMemberIdAndStatus(@Param("memberId") Long memberId, @Param("status") MatchStatus status);
 
+    @Query("select applies from ApplyRecord applies where applies.isMatched=:status and applies.post.id=:postId")
+    List<ApplyRecord> findApplyProfilesByMemberIdAndStatus(@Param("postId") Long postId, @Param("status") MatchStatus status);
 
 
 }

--- a/src/main/java/org/cobee/server/recruit/repository/ApplyRecordRepository.java
+++ b/src/main/java/org/cobee/server/recruit/repository/ApplyRecordRepository.java
@@ -16,11 +16,9 @@ public interface ApplyRecordRepository extends JpaRepository<ApplyRecord, Long> 
     @Query("select applies from ApplyRecord applies where applies.post.id=:postId")
     List<ApplyRecord> findMyPostAppliers(@Param("postId") Long postId);
 
-    // 내가 지원한 구인글(= ON_WAIT) 가져오기(프론트상 첫번째 탭), MATCHING인 것 status 변수로 가져오기
+    // 내가 지원한 구인글 매칭상태 변수에 따라 가져오기(on wait, matching, matched)
     @Query("select applies from ApplyRecord applies where applies.isMatched=:status and applies.member.id=:memberId")
     List<ApplyRecord> findApplyRecordsByMemberIdAndStatus(@Param("memberId") Long memberId, @Param("status") MatchStatus status);
-
-    // 매칭 완료된 구인글 보기 (MATCHED 상태 - 프론트상 2번쨰 탭)
 
 
 

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -51,9 +51,9 @@ public class ApplyService {
         return ApplyResponse.from(applyRecord);
     }
 
-    public List<RecruitResponse> getMyApplies(Long memberId) {
+    public List<RecruitResponse> getMyAppliesOnWait(Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow();
-        List<ApplyRecord> myRecords = applyRepository.findApplyRecordsByMemberId(memberId);
+        List<ApplyRecord> myRecords = applyRepository.findApplyRecordsByMemberIdAndStatus(memberId, MatchStatus.ON_WAIT);
         List<RecruitResponse> myApplies = new ArrayList<>();
         for (ApplyRecord record : myRecords){
             myApplies.add(RecruitResponse.from(record.getPost(), member));
@@ -65,7 +65,7 @@ public class ApplyService {
         // TODO : 현재 로그인된 사용자 검증은 하는데 작성자인지 검증하는거 넣어야함.
         memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-        List<ApplyRecord> records = applyRepository.findMyPostAppliers(postId);
+        List<ApplyRecord> records = applyRepository.findMyPostAppliers(memberId, postId);
         List<PublicProfileResponseDto> appliers = new ArrayList<>();
         // get()은 null이 있다면 NPE 터뜨림 -> TODO : 근데 현재 공개프로필은 필수 작성이므로 NPE 처리 안 함 (나중에 필요시 리팩토링할것)
         for (ApplyRecord record : records){

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -1,8 +1,11 @@
 package org.cobee.server.recruit.service;
 
 import lombok.RequiredArgsConstructor;
+import org.cobee.server.global.error.code.ErrorCode;
+import org.cobee.server.global.error.exception.CustomException;
 import org.cobee.server.member.domain.Member;
 import org.cobee.server.member.repository.MemberRepository;
+import org.cobee.server.publicProfile.dto.PublicProfileResponseDto;
 import org.cobee.server.recruit.domain.ApplyRecord;
 import org.cobee.server.recruit.domain.RecruitPost;
 import org.cobee.server.recruit.domain.enums.MatchStatus;
@@ -56,5 +59,18 @@ public class ApplyService {
             myApplies.add(RecruitResponse.from(record.getPost(), member));
         }
         return myApplies;
+    }
+
+    public List<PublicProfileResponseDto> getMyAppliers(Long postId, Long memberId) {
+        // TODO : 현재 로그인된 사용자 검증은 하는데 작성자인지 검증하는거 넣어야함.
+        memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        List<ApplyRecord> records = applyRepository.findMyPostAppliers(postId);
+        List<PublicProfileResponseDto> appliers = new ArrayList<>();
+        // get()은 null이 있다면 NPE 터뜨림 -> TODO : 근데 현재 공개프로필은 필수 작성이므로 NPE 처리 안 함 (나중에 필요시 리팩토링할것)
+        for (ApplyRecord record : records){
+            appliers.add(PublicProfileResponseDto.from(record.getMember().getPublicProfile(), record.getMember()));
+        }
+        return appliers;
     }
 }

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -43,12 +43,18 @@ public class ApplyService {
         return ApplyResponse.from(applyRecord);
     }
 
-    public ApplyResponse accept(Long applyId, ApplyAcceptRequest applyAccept){
+    public ApplyResponse accept(Long memberId, Long applyId, ApplyAcceptRequest applyAccept){
         ApplyRecord applyRecord = applyRepository.findById(applyId).orElseThrow(()->new CustomException(ErrorCode.APPLY_NOT_FOUND));
-        Boolean accept = applyAccept.getIsAccept();
-        applyRecord.acceptMatching(accept);
-        applyRepository.save(applyRecord);
-        return ApplyResponse.from(applyRecord);
+        Long checkAuthor = applyRecord.getPost().getMember().getId();
+        if(memberId.equals(checkAuthor)) {
+            Boolean accept = applyAccept.getIsAccept();
+            applyRecord.acceptMatching(accept);
+            applyRepository.save(applyRecord);
+            return ApplyResponse.from(applyRecord);
+        } else {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
     }
 
     public List<RecruitResponse> getMyAppliesOnWait(Long memberId) {

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -108,5 +108,59 @@ public class ApplyService {
 
     }
 
+    public List<PublicProfileResponseDto> getMyOnConsideredPostAppliers(Long postId, Long memberId) {
+        // 작성자 본인 확인 체크
+        RecruitPost post = postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        Long checkAuthor = post.getMember().getId();
+
+
+        if (checkAuthor.equals(memberId)){
+            List<ApplyRecord> records = applyRepository.findApplyProfilesByMemberIdAndStatus(postId, MatchStatus.ON_WAIT);
+            List<PublicProfileResponseDto> appliers = new ArrayList<>();
+            for (ApplyRecord record : records){
+                appliers.add(PublicProfileResponseDto.from(record.getMember().getPublicProfile(), record.getMember()));
+            }
+            return appliers;
+        } else {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    public List<PublicProfileResponseDto> getMyOnApprovedPostAppliers(Long postId, Long memberId) {
+        // 작성자 본인 확인 체크
+        RecruitPost post = postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        Long checkAuthor = post.getMember().getId();
+
+        if (checkAuthor.equals(memberId)){
+            List<ApplyRecord> records = applyRepository.findApplyProfilesByMemberIdAndStatus(postId, MatchStatus.MATCHING);
+            List<PublicProfileResponseDto> appliers = new ArrayList<>();
+
+            for (ApplyRecord record : records){
+                appliers.add(PublicProfileResponseDto.from(record.getMember().getPublicProfile(), record.getMember()));
+            }
+            return appliers;
+        } else {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    public List<PublicProfileResponseDto> getMyRejectedPostAppliers(Long postId, Long memberId) {
+        // 작성자 본인 확인 체크
+        RecruitPost post = postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        Long checkAuthor = post.getMember().getId();
+
+        if (checkAuthor.equals(memberId)){
+            List<ApplyRecord> records = applyRepository.findApplyProfilesByMemberIdAndStatus(postId, MatchStatus.REJECTED);
+            List<PublicProfileResponseDto> appliers = new ArrayList<>();
+
+            for (ApplyRecord record : records){
+                appliers.add(PublicProfileResponseDto.from(record.getMember().getPublicProfile(), record.getMember()));
+            }
+            return appliers;
+        } else {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+
 
 }

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -5,6 +5,7 @@ import org.cobee.server.member.domain.Member;
 import org.cobee.server.member.repository.MemberRepository;
 import org.cobee.server.recruit.domain.ApplyRecord;
 import org.cobee.server.recruit.domain.RecruitPost;
+import org.cobee.server.recruit.domain.enums.MatchStatus;
 import org.cobee.server.recruit.dto.ApplyAcceptRequest;
 import org.cobee.server.recruit.dto.ApplyRequest;
 import org.cobee.server.recruit.dto.ApplyResponse;
@@ -26,7 +27,7 @@ public class ApplyService {
         ApplyRecord applyRecord = ApplyRecord.builder()
                 .post(post)
                 .member(member)
-                .isMatched(false)
+                .isMatched(MatchStatus.NONE)
                 .submittedAt(LocalDate.now())
                 .build();
 

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -1,0 +1,14 @@
+package org.cobee.server.recruit.service;
+
+import lombok.RequiredArgsConstructor;
+import org.cobee.server.recruit.dto.ApplyRequest;
+import org.cobee.server.recruit.dto.ApplyResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ApplyService {
+    public ApplyResponse apply(Long memberId, ApplyRequest request) {
+        return null;
+    }
+}

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -71,6 +71,16 @@ public class ApplyService {
         return myApplies;
     }
 
+    public List<RecruitResponse> getMyAppliesOnMatched(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        List<ApplyRecord> myRecords = applyRepository.findApplyRecordsByMemberIdAndStatus(memberId, MatchStatus.MATCHED);
+        List<RecruitResponse> myApplies = new ArrayList<>();
+        for (ApplyRecord record : myRecords){
+            myApplies.add(RecruitResponse.from(record.getPost(), member));
+        }
+        return myApplies;
+    }
+
     public List<PublicProfileResponseDto> getMyPostAppliers(Long postId, Long memberId) {
         // TODO : 현재 로그인된 사용자 검증은 하는데 작성자인지 검증하는거 넣어야함.
         memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -83,4 +93,6 @@ public class ApplyService {
         }
         return appliers;
     }
+
+
 }

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -33,7 +33,7 @@ public class ApplyService {
         ApplyRecord applyRecord = ApplyRecord.builder()
                 .post(post)
                 .member(member)
-                .isMatched(MatchStatus.NONE)
+                .isMatched(MatchStatus.ON_WAIT)
                 .submittedAt(LocalDate.now())
                 .build();
 

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -9,11 +9,14 @@ import org.cobee.server.recruit.domain.enums.MatchStatus;
 import org.cobee.server.recruit.dto.ApplyAcceptRequest;
 import org.cobee.server.recruit.dto.ApplyRequest;
 import org.cobee.server.recruit.dto.ApplyResponse;
+import org.cobee.server.recruit.dto.RecruitResponse;
 import org.cobee.server.recruit.repository.ApplyRecordRepository;
 import org.cobee.server.recruit.repository.RecruitPostRepository;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -45,4 +48,13 @@ public class ApplyService {
         return ApplyResponse.from(applyRecord);
     }
 
+    public List<RecruitResponse> getMyApplies(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        List<ApplyRecord> myRecords = applyRepository.findApplyRecordsByMemberId(memberId);
+        List<RecruitResponse> myApplies = new ArrayList<>();
+        for (ApplyRecord record : myRecords){
+            myApplies.add(RecruitResponse.from(record.getPost(), member));
+        }
+        return myApplies;
+    }
 }

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -5,6 +5,7 @@ import org.cobee.server.member.domain.Member;
 import org.cobee.server.member.repository.MemberRepository;
 import org.cobee.server.recruit.domain.ApplyRecord;
 import org.cobee.server.recruit.domain.RecruitPost;
+import org.cobee.server.recruit.dto.ApplyAcceptRequest;
 import org.cobee.server.recruit.dto.ApplyRequest;
 import org.cobee.server.recruit.dto.ApplyResponse;
 import org.cobee.server.recruit.repository.ApplyRecordRepository;
@@ -34,4 +35,13 @@ public class ApplyService {
         applyRepository.save(applyRecord);
         return ApplyResponse.from(applyRecord);
     }
+
+    public ApplyResponse accept(Long applyId, ApplyAcceptRequest applyAccept){
+        ApplyRecord applyRecord = applyRepository.findById(applyId).orElseThrow();
+        Boolean accept = applyAccept.getIsAccept();
+        applyRecord.acceptMatching(accept);
+        applyRepository.save(applyRecord);
+        return ApplyResponse.from(applyRecord);
+    }
+
 }

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -1,14 +1,37 @@
 package org.cobee.server.recruit.service;
 
 import lombok.RequiredArgsConstructor;
+import org.cobee.server.member.domain.Member;
+import org.cobee.server.member.repository.MemberRepository;
+import org.cobee.server.recruit.domain.ApplyRecord;
+import org.cobee.server.recruit.domain.RecruitPost;
 import org.cobee.server.recruit.dto.ApplyRequest;
 import org.cobee.server.recruit.dto.ApplyResponse;
+import org.cobee.server.recruit.repository.ApplyRecordRepository;
+import org.cobee.server.recruit.repository.RecruitPostRepository;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
 public class ApplyService {
+    private final MemberRepository memberRepository;
+    private final RecruitPostRepository postRepository;
+    private final ApplyRecordRepository applyRepository;
     public ApplyResponse apply(Long memberId, ApplyRequest request) {
-        return null;
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        RecruitPost post = postRepository.findById(request.getPostId()).orElseThrow();
+        ApplyRecord applyRecord = ApplyRecord.builder()
+                .post(post)
+                .member(member)
+                .isMatched(false)
+                .submittedAt(LocalDate.now())
+                .build();
+
+        post.addApply(applyRecord);
+        //postRepository.save(post); 이거 대신에 RecruitPost에 setting하는 메서드로
+        applyRepository.save(applyRecord);
+        return ApplyResponse.from(applyRecord);
     }
 }

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -61,11 +61,21 @@ public class ApplyService {
         return myApplies;
     }
 
-    public List<PublicProfileResponseDto> getMyAppliers(Long postId, Long memberId) {
+    public List<RecruitResponse> getMyAppliesOnMatching(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        List<ApplyRecord> myRecords = applyRepository.findApplyRecordsByMemberIdAndStatus(memberId, MatchStatus.MATCHING);
+        List<RecruitResponse> myApplies = new ArrayList<>();
+        for (ApplyRecord record : myRecords){
+            myApplies.add(RecruitResponse.from(record.getPost(), member));
+        }
+        return myApplies;
+    }
+
+    public List<PublicProfileResponseDto> getMyPostAppliers(Long postId, Long memberId) {
         // TODO : 현재 로그인된 사용자 검증은 하는데 작성자인지 검증하는거 넣어야함.
         memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-        List<ApplyRecord> records = applyRepository.findMyPostAppliers(memberId, postId);
+        List<ApplyRecord> records = applyRepository.findMyPostAppliers(postId);
         List<PublicProfileResponseDto> appliers = new ArrayList<>();
         // get()은 null이 있다면 NPE 터뜨림 -> TODO : 근데 현재 공개프로필은 필수 작성이므로 NPE 처리 안 함 (나중에 필요시 리팩토링할것)
         for (ApplyRecord record : records){

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -27,6 +27,8 @@ public class ApplyService {
     private final MemberRepository memberRepository;
     private final RecruitPostRepository postRepository;
     private final ApplyRecordRepository applyRepository;
+
+    // TODO : 중복 처리 되지 않게 수정
     public ApplyResponse apply(Long memberId, ApplyRequest request) {
         Member member = memberRepository.findById(memberId).orElseThrow();
         RecruitPost post = postRepository.findById(request.getPostId()).orElseThrow();
@@ -87,7 +89,7 @@ public class ApplyService {
         return myApplies;
     }
 
-    public List<PublicProfileResponseDto> getMyPostAppliers(Long postId, Long memberId) {
+    public List<PublicProfileResponseDto> getMyAllPostAppliers(Long postId, Long memberId) {
         // 작성자 본인 확인 체크
         RecruitPost post = postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
         Long checkAuthor = post.getMember().getId();

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -44,7 +44,7 @@ public class ApplyService {
     }
 
     public ApplyResponse accept(Long applyId, ApplyAcceptRequest applyAccept){
-        ApplyRecord applyRecord = applyRepository.findById(applyId).orElseThrow();
+        ApplyRecord applyRecord = applyRepository.findById(applyId).orElseThrow(()->new CustomException(ErrorCode.APPLY_NOT_FOUND));
         Boolean accept = applyAccept.getIsAccept();
         applyRecord.acceptMatching(accept);
         applyRepository.save(applyRecord);

--- a/src/main/java/org/cobee/server/recruit/service/ApplyService.java
+++ b/src/main/java/org/cobee/server/recruit/service/ApplyService.java
@@ -88,16 +88,22 @@ public class ApplyService {
     }
 
     public List<PublicProfileResponseDto> getMyPostAppliers(Long postId, Long memberId) {
-        // TODO : 현재 로그인된 사용자 검증은 하는데 작성자인지 검증하는거 넣어야함.
-        memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-        List<ApplyRecord> records = applyRepository.findMyPostAppliers(postId);
-        List<PublicProfileResponseDto> appliers = new ArrayList<>();
-        // get()은 null이 있다면 NPE 터뜨림 -> TODO : 근데 현재 공개프로필은 필수 작성이므로 NPE 처리 안 함 (나중에 필요시 리팩토링할것)
-        for (ApplyRecord record : records){
-            appliers.add(PublicProfileResponseDto.from(record.getMember().getPublicProfile(), record.getMember()));
+        // 작성자 본인 확인 체크
+        RecruitPost post = postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        Long checkAuthor = post.getMember().getId();
+
+        if (checkAuthor.equals(memberId)){
+            List<ApplyRecord> records = applyRepository.findMyPostAppliers(postId);
+            List<PublicProfileResponseDto> appliers = new ArrayList<>();
+
+            for (ApplyRecord record : records){
+                appliers.add(PublicProfileResponseDto.from(record.getMember().getPublicProfile(), record.getMember()));
+            }
+            return appliers;
+        } else {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
-        return appliers;
+
     }
 
 

--- a/src/main/java/org/cobee/server/recruit/service/RecruitService.java
+++ b/src/main/java/org/cobee/server/recruit/service/RecruitService.java
@@ -5,13 +5,17 @@ import org.cobee.server.global.error.code.ErrorCode;
 import org.cobee.server.global.error.exception.CustomException;
 import org.cobee.server.member.domain.Member;
 import org.cobee.server.member.repository.MemberRepository;
+import org.cobee.server.recruit.domain.ApplyRecord;
 import org.cobee.server.recruit.domain.RecruitPost;
+import org.cobee.server.recruit.domain.enums.MatchStatus;
 import org.cobee.server.recruit.domain.enums.RecruitStatus;
 import org.cobee.server.recruit.dto.RecruitRequest;
 import org.cobee.server.recruit.dto.RecruitResponse;
+import org.cobee.server.recruit.repository.ApplyRecordRepository;
 import org.cobee.server.recruit.repository.RecruitPostRepository;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,6 +25,7 @@ import java.util.List;
 public class RecruitService {
     private final RecruitPostRepository recruitRepository;
     private final MemberRepository memberRepository;
+    private final ApplyRecordRepository applyRepository;
 
     public RecruitResponse createRecruitPost(RecruitRequest request, Long memberId){
         Member member = memberRepository.findById(memberId).orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -46,6 +51,13 @@ public class RecruitService {
                 .build();
         recruitRepository.save(recruitPost);
 
+        ApplyRecord apply = ApplyRecord.builder()
+                .submittedAt(LocalDate.now())
+                .post(recruitPost)
+                .isMatched(MatchStatus.MATCHING)
+                .member(member)
+                .build();
+        applyRepository.save(apply);
 
         return RecruitResponse.from(recruitPost, member);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: cobee server
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/postgres
+    url: jdbc:postgresql://localhost:5432/cobeeMate
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: cobee server
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/cobeeMate
+    url: jdbc:postgresql://localhost:5432/cobeeMate1
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## 💚 연관된 이슈 번호
- closes #28 
  이런 식으로 닫아주세요.

## ✅ 작업 내용
> 이번 pr 에서 작업한 내용을 간략하게 설명해주세요.
1. 구인글에 지원신청 API 구현 
2. 매칭 상태에 따라 지원중인/매칭중인(=채팅초대된 구인글)/매칭된 구인글 목록 조회 API
3. 내 구인글에 (id기준으로) 지원한 사람의 공개 프로필 조회 API 
4. 나에게 지원한 사람을 승인할지 / 거절할지 구현하는 API (ON_WAIT -> MATCHING 상태로 변화) 

## 📸 스크린샷 (선택)
<img width="1435==" height="500" alt="image" src="https://github.com/user-attachments/assets/831fc7ff-8703-49b5-8706-f00a0680571c" />
매칭완료된 구인글 조회 API
<img width="1435" height="500" alt="Cap 2025-08-19 17-59-40-925" src="https://github.com/user-attachments/assets/05219f17-55f7-4ee8-a91b-6fa34dad17a8" />
매칭중인 구인글 조회 API
<img width="1422" height="550" alt="image" src="https://github.com/user-attachments/assets/916b35a0-b63f-4132-a630-7292851e5aa1" />
지원한 구인글 조회

<img width="1435" height="500" alt="image" src="https://github.com/user-attachments/assets/cd275c2c-c463-46c2-9fad-c4427613be1f" />
구인글에 지원 API (ON_WAIT로 상태 변경) 

<img width="1435" height="500" alt="Cap 2025-08-19 17-57-57-965" src="https://github.com/user-attachments/assets/e10e2703-d72b-469c-8212-e68b4806f454" />
지원 수락 API (MATCHING으로 상태 변경) 

<img width="1435" height="500" alt="Cap 2025-08-19 17-57-17-317" src="https://github.com/user-attachments/assets/ea486af2-fdc0-421e-a864-d4a36e66c699" />
특정 구인글에 지원한 사용자의 공개 프로필 조회 API

<img width="1398" height="500" alt="Cap 2025-08-19 14-27-15-201" src="https://github.com/user-attachments/assets/6a6e88ce-04ac-4de8-952d-ba92dabbd9e5" />
지원자가 없을떄의 response



## 👩‍💻 기타