### PR TITLE
[BE/Feat] 채팅 추가 기능 구현 

### DIFF
--- a/src/main/java/org/cobee/server/chat/domain/ChatRoom.java
+++ b/src/main/java/org/cobee/server/chat/domain/ChatRoom.java
@@ -26,12 +26,18 @@ public class ChatRoom {
     @Column(nullable = false)
     private String name;
 
+    @ManyToOne
+    @JoinColumn(name = "host_id")
+    private Member host;
+
+    @Builder.Default
     @Column(nullable = false)
     private int currentUserCount = 0;
 
     @Column(nullable = false)
     private int maxMemberCount;
 
+    @Builder.Default
     @OneToMany(mappedBy = "chatRoom")
     private Set<Member> users = new HashSet<>();
 

--- a/src/main/java/org/cobee/server/chat/dto/ChatRoomCreateRequestDto.java
+++ b/src/main/java/org/cobee/server/chat/dto/ChatRoomCreateRequestDto.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class ChatRoomCreateRequestDto {
     private String name;
     private int maxUserCount;
+    private Long postId;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: cobee server
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/cobeeMate1
+    url: ${POSTGRES_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## 💚 연관된 이슈 번호
- closes #36 

## ✅ 작업 내용
1. 채팅방 생성시, 방장 설정 기능을 추가했습니다.
2. 방장이 채팅방 내의 다른 사용자를 강퇴할 수 있는 기능을 추가했습니다.
3. 채팅방을 관련 게시글과 연결하는 로직을 추가했습니다.
## 📸 스크린샷 (선택)
- `사용자 강퇴 기능`
<p>
<img width="600" height="600" alt="image" src="https://github.com/user-attachments/assets/511273c1-eeb8-48d0-a2e8-58ff2fd0a932" />
</p>

- `채팅방과 관련된 게시글과 연결 /채팅방 개설하는 사용자를 방장으로 지정`
<p>
<img width="600" height="230" alt="image" src="https://github.com/user-attachments/assets/ad85d79f-c76d-4e0d-8472-b8940fcf11dd" />
</p>


## 👩‍💻 기타
- `mongo`, `postgresql` 관련 `docker-compose.yml` 은 따로 노션에 올려뒀습니다.
- `application.yml` 도 따로 올려뒀으니 확인 부탁드려요.
> 따로 궁금한 점은 댓글로 남겨주세요!! 😄 