### PR TITLE
[BE/CHORE] Dockerfile Gradle 빌드 권한 오류 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-# 빌드 스테이지
-FROM gradle:8.1.1-jdk17-alpine AS builder
-WORKDIR /home/gradle/project
-COPY --chown=gradle:gradle . .
-RUN gradle clean build -x test --no-daemon
+FROM eclipse-temurin:17-jdk AS builder
+WORKDIR /workspace
+COPY gradlew ./
+COPY gradle gradle
+RUN chmod +x ./gradlew
+COPY . .
+RUN ./gradlew clean build -x test --no-daemon
 
-# 런타임 스테이지
 FROM openjdk:17-jdk-slim-buster
 WORKDIR /app
-COPY --from=builder /home/gradle/project/build/libs/*.jar /app/app.jar
+COPY --from=builder /workspace/build/libs/*.jar /app/app.jar
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","/app/app.jar"]


### PR DESCRIPTION
## 💚 연관된 이슈 번호
#47 
(Gradle 컨테이너의 기본 유저가 gradle인데, .gradle이 없거나 소유권이 어긋나 있어서 캐시에 JAR을 못 쓰면서 빌드가 터지는 상황)