### PR TITLE
[BE/CHORE] env 참조 오류 수정(#47)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,18 +4,18 @@ on:
   push:
     branches: [ develop ]
 
+# 모든 변수를 전역(Global) 환경 변수로 정의!!!
 env:
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   REGION: asia-northeast3
   REPO_NAME: cobee-server
+  # IMAGE_REPO가 다른 env 변수들을 참조할 수 있도록 전역에 위치
+  IMAGE_REPO: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO_NAME }}/cobee-server
+  IMAGE_TAG: ${{ github.sha }}
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    env:
-      IMAGE_REPO: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO_NAME }}/cobee-server
-      IMAGE_TAG: ${{ github.sha }}
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,18 +4,17 @@ on:
   push:
     branches: [ develop ]
 
-# 모든 변수를 전역(Global) 환경 변수로 정의!!!
 env:
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-  REGION: asia-northeast3
-  REPO_NAME: cobee-server
-  # IMAGE_REPO가 다른 env 변수들을 참조할 수 있도록 전역에 위치
-  IMAGE_REPO: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPO_NAME }}/cobee-server
+  REGION: ${{ secrets.GCP_REGION }}
+  REPO_NAME: ${{ secrets.AR_REPO_NAME }}
+  IMAGE_REPO: ${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.AR_REPO_NAME }}/cobee-server
   IMAGE_TAG: ${{ github.sha }}
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -28,7 +27,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
         with:
-          project_id: ${{ env.PROJECT_ID }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
@@ -48,7 +47,7 @@ jobs:
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: cobee-server
-          region: ${{ env.REGION }}
+          region: ${{ secrets.GCP_REGION }}
           image: ${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}
           env_vars: |
             POSTGRES_URL=${{ secrets.POSTGRES_URL }}


### PR DESCRIPTION
## 💚 연관된 이슈 번호
#47
- IMAGE_REPO와 IMAGE_TAG를 최상위 전역 env 블록으로 옮김 이렇게 하면 IMAGE_REPO를 정의하는 시점에서 REGION, PROJECT_ID, REPO_NAME이 이미 유효한 전역 변수로 존재하므로 문제없이 참조 가능!
-  secret 키를 추가