### PR TITLE
bugfix: chatroom 에서 내가 속한 채팅방 조회할 떄 lob 오류 해결 (#93)

### DIFF
--- a/src/main/java/org/cobee/server/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/org/cobee/server/chat/repository/ChatRoomRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-    @Query("SELECT r FROM ChatRoom r JOIN r.users u WHERE u = :member")
+    @Query("SELECT r FROM ChatRoom r JOIN FETCH r.post JOIN r.users u WHERE u = :member")
     Optional<ChatRoom> findByMember(@Param("member") Member member);
 
 }


### PR DESCRIPTION
## 💚 연관된 이슈 번호
- closes #93

## ✅ 작업 내용
1. 내가 속한 채팅방 정보를 가져오는 기능에서 구인글이 LOB 필드를 스트림 형태로 처리하는데, 여기서 지연로딩이 발생하면서 오류 발생됨. 그래서 레포지토리에서 JPQL 쿼리를 수정해서 바로 ChatRoom을 조회할 때 RecruitPost를 함께 가져오도록 명시적으로 지정해서 수정하였습니다. 
