### PR TITLE
[BE/FEAT] 채팅방에 속한 유저 정보 반환

### DIFF
--- a/src/main/java/org/cobee/server/chat/controller/ChatRoomController.java
+++ b/src/main/java/org/cobee/server/chat/controller/ChatRoomController.java
@@ -86,6 +86,7 @@ public class ChatRoomController {
         List<ChatMessage> history = chatService.getChatHistory(roomId);
         return ApiResponse.success("채팅 기록 조회 성공", "CHAT_HISTORY", ChatRoomMapper.toMessageDtoList(history));
     }
+
     //내가 속한 채팅방 조회
     @GetMapping("/rooms/my")
     public ApiResponse<ChatRoomResponseDto> getMyRoom(@AuthenticationPrincipal PrincipalDetails principal) {
@@ -96,6 +97,7 @@ public class ChatRoomController {
             return ApiResponse.failure("속한 채팅방이 없습니다", "NO_CHAT_ROOM", "No chat room found for the user");
         }
     }
+
     //채팅방 내의 유저 목록 조회
     @GetMapping("/rooms/{roomId}/users")
     public ApiResponse<List<ChatRoomUserListResponseDto>> getUsersInRoom(@PathVariable Long roomId) {
@@ -106,6 +108,7 @@ public class ChatRoomController {
             return ApiResponse.failure("채팅방을 찾을 수 없습니다", "CHAT_ROOM_NOT_FOUND", e.getMessage());
         }
     }
+
     //채팅방 나가기
     @PostMapping("/rooms/exit/{roomId}")
     public ApiResponse<Void> exitRoom(@PathVariable Long roomId, @RequestBody Map<String, Object> payload) {
@@ -139,6 +142,7 @@ public class ChatRoomController {
             return ApiResponse.failure("채팅방을 찾을 수 없습니다", "CHAT_ROOM_NOT_FOUND", e.getMessage());
         }
     }
+
     // 채팅방에서 유저 강퇴 (채팅방 방장인 host만 가능)
     @DeleteMapping("/rooms/{roomId}/users/{userId}")
     public ApiResponse<Void> outUser(

--- a/src/main/java/org/cobee/server/chat/controller/ChatRoomController.java
+++ b/src/main/java/org/cobee/server/chat/controller/ChatRoomController.java
@@ -11,6 +11,7 @@ import org.cobee.server.chat.dto.ChatRoomCreateRequestDto;
 import org.cobee.server.chat.dto.ChatRoomMapper;
 import org.cobee.server.chat.dto.ChatRoomResponseDto;
 import org.cobee.server.chat.dto.ChatMessageResponseDto;
+import org.cobee.server.chat.dto.ChatRoomUserListResponseDto;
 import org.cobee.server.chat.dto.JoinRoomRequestDto;
 import org.cobee.server.chat.service.ChatRoomService;
 import org.cobee.server.chat.service.ChatService;
@@ -93,6 +94,16 @@ public class ChatRoomController {
             return ApiResponse.success("내 채팅방 조회 성공", "MY_CHAT_ROOM", ChatRoomMapper.toDto(myRoom.get()));
         } else {
             return ApiResponse.failure("속한 채팅방이 없습니다", "NO_CHAT_ROOM", "No chat room found for the user");
+        }
+    }
+    //채팅방 내의 유저 목록 조회
+    @GetMapping("/rooms/{roomId}/users")
+    public ApiResponse<List<ChatRoomUserListResponseDto>> getUsersInRoom(@PathVariable Long roomId) {
+        try {
+            List<ChatRoomUserListResponseDto> users = chatRoomService.getUsernamesInRoom(roomId);
+            return ApiResponse.success("채팅방 유저 목록 조회 성공", "CHAT_ROOM_USERS", users);
+        } catch (IllegalArgumentException e) {
+            return ApiResponse.failure("채팅방을 찾을 수 없습니다", "CHAT_ROOM_NOT_FOUND", e.getMessage());
         }
     }
     //채팅방 나가기

--- a/src/main/java/org/cobee/server/chat/dto/ChatRoomMapper.java
+++ b/src/main/java/org/cobee/server/chat/dto/ChatRoomMapper.java
@@ -10,6 +10,7 @@ public class ChatRoomMapper {
     public static ChatRoomResponseDto toDto(ChatRoom room) {
         return ChatRoomResponseDto.builder()
                 .id(room.getId())
+                .postId(room.getPost().getId())
                 .name(room.getName())
                 .maxMemberCount(room.getMaxMemberCount())
                 .currentUserCount(room.getCurrentUserCount())

--- a/src/main/java/org/cobee/server/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/org/cobee/server/chat/dto/ChatRoomResponseDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public class ChatRoomResponseDto {
     private Long id;
     private String name;
+    private Long postId;
     private int maxMemberCount;
     private int currentUserCount;
 }

--- a/src/main/java/org/cobee/server/chat/dto/ChatRoomUserListResponseDto.java
+++ b/src/main/java/org/cobee/server/chat/dto/ChatRoomUserListResponseDto.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 @Builder
 public class ChatRoomUserListResponseDto {
     private Long id;
-    private Long postId;
     private String name;
     private boolean isHost;
 }

--- a/src/main/java/org/cobee/server/chat/dto/ChatRoomUserListResponseDto.java
+++ b/src/main/java/org/cobee/server/chat/dto/ChatRoomUserListResponseDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Builder
 public class ChatRoomUserListResponseDto {
     private Long id;
+    private Long postId;
     private String name;
     private boolean isHost;
 }

--- a/src/main/java/org/cobee/server/chat/dto/ChatRoomUserListResponseDto.java
+++ b/src/main/java/org/cobee/server/chat/dto/ChatRoomUserListResponseDto.java
@@ -1,0 +1,12 @@
+package org.cobee.server.chat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatRoomUserListResponseDto {
+    private Long id;
+    private String name;
+    private boolean isHost;
+}

--- a/src/main/java/org/cobee/server/chat/service/ChatRoomService.java
+++ b/src/main/java/org/cobee/server/chat/service/ChatRoomService.java
@@ -38,13 +38,9 @@ public class ChatRoomService {
                 .post(post)
                 .build();
 
-        Member isHostUser = memberRepository.findById(host.getId())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        // 멤버에서의 isHost 업데이트
-        if (isHostUser.getIsHost() == false) {
-            isHostUser.setIsHost(true);
-            memberRepository.save(isHostUser);
+        if (host.getIsHost() == false) {
+            host.setIsHost(true);
+            memberRepository.save(host);
         }
 
         return chatRoomRepository.save(newRoom);

--- a/src/main/java/org/cobee/server/chat/service/ChatRoomService.java
+++ b/src/main/java/org/cobee/server/chat/service/ChatRoomService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cobee.server.chat.domain.ChatRoom;
 import org.cobee.server.chat.dto.ChatRoomCreateRequestDto;
+import org.cobee.server.chat.dto.ChatRoomUserListResponseDto;
 import org.cobee.server.chat.repository.ChatRoomRepository;
 import org.cobee.server.global.error.code.ErrorCode;
 import org.cobee.server.global.error.exception.CustomException;
@@ -36,6 +37,15 @@ public class ChatRoomService {
                 .host(host)
                 .post(post)
                 .build();
+
+        Member isHostUser= memberRepository.findById(host.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 멤버에서의 isHost 업데이트
+        if(isHostUser.getIsHost() == false) {
+        	isHostUser.setIsHost(true);
+        	memberRepository.save(isHostUser);
+        }
 
         return chatRoomRepository.save(newRoom);
     }
@@ -129,4 +139,18 @@ public class ChatRoomService {
     public Optional<ChatRoom> findRoomByUser(Member member) {
         return chatRoomRepository.findByMember(member);
     }
+
+    public List<ChatRoomUserListResponseDto> getUsernamesInRoom(Long roomId) {
+        ChatRoom room = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        return room.getUsers().stream()
+                .map(user -> ChatRoomUserListResponseDto.builder()
+                        .id(user.getId())
+                        .name(user.getName())
+                        .isHost(user.getIsHost())
+                        .build())
+                .toList();
+    }
+
 }

--- a/src/main/java/org/cobee/server/chat/service/ChatRoomService.java
+++ b/src/main/java/org/cobee/server/chat/service/ChatRoomService.java
@@ -38,13 +38,13 @@ public class ChatRoomService {
                 .post(post)
                 .build();
 
-        Member isHostUser= memberRepository.findById(host.getId())
+        Member isHostUser = memberRepository.findById(host.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 멤버에서의 isHost 업데이트
-        if(isHostUser.getIsHost() == false) {
-        	isHostUser.setIsHost(true);
-        	memberRepository.save(isHostUser);
+        if (isHostUser.getIsHost() == false) {
+            isHostUser.setIsHost(true);
+            memberRepository.save(isHostUser);
         }
 
         return chatRoomRepository.save(newRoom);

--- a/src/main/java/org/cobee/server/chat/service/ChatRoomService.java
+++ b/src/main/java/org/cobee/server/chat/service/ChatRoomService.java
@@ -143,6 +143,7 @@ public class ChatRoomService {
         return room.getUsers().stream()
                 .map(user -> ChatRoomUserListResponseDto.builder()
                         .id(user.getId())
+                        .postId(room.getPost().getId())
                         .name(user.getName())
                         .isHost(user.getIsHost())
                         .build())

--- a/src/main/java/org/cobee/server/chat/service/ChatRoomService.java
+++ b/src/main/java/org/cobee/server/chat/service/ChatRoomService.java
@@ -143,7 +143,6 @@ public class ChatRoomService {
         return room.getUsers().stream()
                 .map(user -> ChatRoomUserListResponseDto.builder()
                         .id(user.getId())
-                        .postId(room.getPost().getId())
                         .name(user.getName())
                         .isHost(user.getIsHost())
                         .build())

--- a/src/main/java/org/cobee/server/member/domain/Member.java
+++ b/src/main/java/org/cobee/server/member/domain/Member.java
@@ -123,5 +123,9 @@ public class Member extends BaseEntity {
         this.fcmToken=fcmToken;
         return fcmToken;
     }
+
+    public void setIsHost(boolean b) {
+        this.isHost=b;
+    }
 }
 


### PR DESCRIPTION
## 💚 연관된 이슈 번호
- closes #99

## ✅ 작업 내용
1. 채팅방에 속한 사용자 정보를 보내주는 기능 추가 (사용자 id, name, ishost, postId) 했습니다.
2. 멤버쪽에서도 채팅방을 만들게 되면 host 정보를 저장할 수 있게 수정했습니다.