### PR TITLE
[BE/Bugfix] DB 커넥션 풀/hikari 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,15 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
+    hikari:
+      maximum-pool-size: 8
+      minimum-idle: 2
+      idle-timeout: 600000        # 10m
+      max-lifetime: 1800000       # 30m
+      keepalive-time: 300000      # 5m
+      connection-timeout: 30000   # 30s
+      validation-timeout: 5000    # 5s
+
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## 💚 연관된 이슈 번호
- closes #125

## ✅ 작업 내용
1. DB 커넥션 풀/hikari 설정 추가
- **Cloud Run**
동시 실행(concurrency): 20
최대 인스턴스: 4
최소 인스턴스(min-instances): 1
 인스턴스당 처리량(20) × 최대 인스턴스(4) = 80 동시 요청을 유지
