### PR TITLE
[BE/REFACTOR] 채팅방, 채팅 삭제 기능 추가

### DIFF
--- a/src/main/java/org/cobee/server/auth/controller/AuthController.java
+++ b/src/main/java/org/cobee/server/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import org.cobee.server.auth.dto.RefreshTokenRequest;
 import org.cobee.server.auth.jwt.TokenInfo;
 import org.cobee.server.auth.service.AuthService;
 import org.cobee.server.auth.service.PrincipalDetails;
+import org.cobee.server.chat.service.ChatRoomService;
 import org.cobee.server.chat.service.ChatService;
 import org.cobee.server.global.response.ApiResponse;
 import org.cobee.server.member.domain.Member;
@@ -22,6 +23,7 @@ public class AuthController {
 
     private final AuthService authService;
     private final ChatService chatService;
+    private final ChatRoomService chatRoomService;
 
     @GetMapping()
     public ApiResponse<MemberInfoDto> getUserInfo(@AuthenticationPrincipal PrincipalDetails principalDetails) {
@@ -48,6 +50,7 @@ public class AuthController {
         Member member = principalDetails.getMember();
         // 탈퇴시, 회원이 작성한 채팅 메시지 삭제
         long deletedCount = chatService.deleteMessagesByMember(member.getId());
+        chatRoomService.removeUserFromRoom(member.getChatRoom().getId(), member.getId());
         authService.withdrawMember(member.getId(), request, response);
         MemberInfoDto memberInfo = MemberInfoDto.from(member);
         return ApiResponse.success("회원 탈퇴 성공 (삭제된 메시지: " + deletedCount + "건)", "200", memberInfo);

--- a/src/main/java/org/cobee/server/chat/controller/ChatRoomController.java
+++ b/src/main/java/org/cobee/server/chat/controller/ChatRoomController.java
@@ -158,6 +158,7 @@ public class ChatRoomController {
     public ApiResponse<Void> deleteRoom(@PathVariable Long roomId) {
         try {
             chatRoomService.deleteChatRoom(roomId);
+            chatService.deleteMessagesByRoom(roomId);
             return ApiResponse.success("채팅방 삭제 성공", "CHAT_ROOM_DELETED");
         } catch (IllegalArgumentException e) {
             return ApiResponse.failure("채팅방을 찾을 수 없습니다", "CHAT_ROOM_NOT_FOUND", e.getMessage());

--- a/src/main/java/org/cobee/server/chat/document/ChatMessage.java
+++ b/src/main/java/org/cobee/server/chat/document/ChatMessage.java
@@ -1,6 +1,5 @@
 package org.cobee.server.chat.document;
 
-
 import com.mongodb.lang.Nullable;
 import java.time.LocalDateTime;
 import java.util.HashSet;

--- a/src/main/java/org/cobee/server/chat/service/ChatService.java
+++ b/src/main/java/org/cobee/server/chat/service/ChatService.java
@@ -70,4 +70,10 @@ public class ChatService {
         return chatMessageRepository.deleteBySenderId(memberId);
     }
 
+    @Transactional
+    public void deleteMessagesByRoom(Long roomId) {
+        List<ChatMessage> messages = chatMessageRepository.findByChatRoomIdOrderByTimestampAsc(roomId);
+        chatMessageRepository.deleteAll(messages);
+    }
+
 }


### PR DESCRIPTION
## 💚 연관된 이슈 번호
- closes #143 

## ✅ 작업 내용
1. 채팅방 삭제가 되면, 그 해당 채팅방의 모든 채팅이 삭제되게 하는 기능을 수정했습니다.
2. 유저가 탈퇴하면, 채팅 기록뿐만 아니라 채팅방에서 나갈 수 있게 수정했습니다. 