### PR TITLE
[BE/BUGFIX] 사용자 탈퇴, 방장의 채팅방 나가기 로직 수정 

### DIFF
--- a/src/main/java/org/cobee/server/auth/controller/AuthController.java
+++ b/src/main/java/org/cobee/server/auth/controller/AuthController.java
@@ -50,7 +50,9 @@ public class AuthController {
         Member member = principalDetails.getMember();
         // 탈퇴시, 회원이 작성한 채팅 메시지 삭제
         long deletedCount = chatService.deleteMessagesByMember(member.getId());
-        chatRoomService.removeUserFromRoom(member.getChatRoom().getId(), member.getId());
+        if(member.getChatRoom() != null){
+            chatRoomService.removeUserFromRoom(member.getChatRoom().getId(), member.getId());
+        }
         authService.withdrawMember(member.getId(), request, response);
         MemberInfoDto memberInfo = MemberInfoDto.from(member);
         return ApiResponse.success("회원 탈퇴 성공 (삭제된 메시지: " + deletedCount + "건)", "200", memberInfo);

--- a/src/main/java/org/cobee/server/chat/service/ChatRoomService.java
+++ b/src/main/java/org/cobee/server/chat/service/ChatRoomService.java
@@ -1,5 +1,6 @@
 package org.cobee.server.chat.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -95,8 +96,13 @@ public class ChatRoomService {
         if (user.getChatRoom() == null || !user.getChatRoom().equals(room)) {
             throw new CustomException(ErrorCode.CHAT_ROOM_USER_NOT_IN_ROOM);
         }
-
-        room.removeUser(user);
+        if(user.getIsHost()){
+            for (Member member : room.getUsers()){
+                room.removeUser(member);
+            }
+        }else{
+            room.removeUser(user);
+        }
         chatRoomRepository.save(room);
     }
 

--- a/src/main/java/org/cobee/server/global/error/code/ErrorCode.java
+++ b/src/main/java/org/cobee/server/global/error/code/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     CHAT_ROOM_USER_NOT_IN_ROOM(HttpStatus.BAD_REQUEST, "CHATROOM-008", "User is not in the ChatRoom"),
     CHAT_ROOM_EXISTS_USER(HttpStatus.BAD_REQUEST, "CHATROOM-009", "User exists in the ChatRoom"),
     CHAT_ROOM_NAME_CANNOT_EMPTY(HttpStatus.BAD_REQUEST, "CHATROOM-010", "ChatRoom name cannot be empty"),
+    CHAT_ROOM_HOST_CANNOT_EXIT(HttpStatus.BAD_REQUEST, "CHATROOM-011", "ChatRoom host cannot exit the room"),
 
 
     LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "LOCATION-001", "Cannot find Location"),


### PR DESCRIPTION
## 💚 연관된 이슈 번호
- closes #157

## ✅ 작업 내용
1. 사용자 탈퇴시, 방에 참여 안 했을 때, 예외처리
2. 방장이 채팅방을 나가려고 할 때, 그 해당 채팅방의 사용자 모두 나가기
